### PR TITLE
Potential fix for code scanning alert no. 34: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -7,6 +7,20 @@ import ProgressBar from '../loading/ProgressBar';
 import { Product, User } from '../../types';
 import { formatDate, formatPrice, sanitizeAltText, sanitizeText } from '../../utils/helpers';
 
+// Sanitizes a URL for use in <img src=...>
+function sanitizeUrl(url?: string): string {
+  if (!url || typeof url !== 'string') return '';
+  // Only allow http(s) URLs and data:image URLs, deny others
+  if (
+    url.startsWith('https://') ||
+    url.startsWith('http://') ||
+    url.startsWith('data:image/')
+  ) {
+    return url;
+  }
+  // fallback avatar if unsafe
+  return 'https://i.pravatar.cc/150?img=1';
+}
 interface ProductCardProps {
   product: Product;
   showInterestCount?: boolean;
@@ -95,7 +109,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
           <div className="pt-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
             <div className="flex items-center">
               <img 
-                src={createdByUser?.avatar} 
+                src={sanitizeUrl(createdByUser?.avatar)} 
                 alt={sanitizeAltText(createdByUser?.name)}
                 className="h-5 w-5 rounded-full mr-1"
               />


### PR DESCRIPTION
Potential fix for [https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/34](https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/34)

To fix the problem, we should ensure that values used for the `src` attribute of an `<img>` are properly sanitized. The best general approach is to verify that the value is either a safe URL, or to restrict it to a set of known-safe patterns. Since in the current codebase avatar is set only as a pravatar URL based on a numeric index, but the code might change, the safest and most future-proof solution is to sanitize the avatar value before rendering. 

This can be achieved by introducing a `sanitizeUrl` helper function in `src/utils/helpers.ts`, and using it in `ProductCard.tsx` wherever user content is used as a URL, notably in the `<img src={createdByUser?.avatar}>` line. The helper should accept a string, and only return it if it matches safe URL patterns (e.g., starts with "https://", or "data:image/", etc.), otherwise return a fallback (e.g., undefined or a default avatar URL). We'll need to add this helper and use it in line 98 of `ProductCard.tsx`.

Specifically:
- In `src/utils/helpers.ts`, define a `sanitizeUrl(url: string)` function.
- In `src/components/product/ProductCard.tsx`, change the `img src={createdByUser?.avatar}` to `img src={sanitizeUrl(createdByUser?.avatar)}`.

If you are limited to only the shown `helpers.ts` API, you may have to add `sanitizeUrl` within ProductCard.tsx—otherwise, best to add it in helpers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
