### PR TITLE
Potential fix for code scanning alert no. 40: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -8,14 +8,16 @@ import { Product, User } from '../../types';
 import { formatDate, formatPrice, sanitizeAltText, sanitizeText } from '../../utils/helpers';
 
 // Sanitizes a URL for use in <img src=...>
+// Strictly only allow valid HTTP(S) image URLs and specific data:image types
 function sanitizeUrl(url?: string): string {
   if (!url || typeof url !== 'string') return '';
-  // Only allow http(s) URLs and data:image URLs, deny others
-  if (
-    url.startsWith('https://') ||
-    url.startsWith('http://') ||
-    url.startsWith('data:image/')
-  ) {
+  // Remove leading/trailing whitespace
+  url = url.trim();
+  // Regular expression for safe http/https URLs ending with an image extension
+  const httpUrlRegex = /^https?:\/\/[^\s]+(\.(jpg|jpeg|png|gif|webp|svg))?([?#][^\s]*)?$/i;
+  // Allow only specific data:image types (png, jpeg, gif, webp, svg)
+  const dataImageRegex = /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,[A-Za-z0-9+\/=]+$/i;
+  if (httpUrlRegex.test(url) || dataImageRegex.test(url)) {
     return url;
   }
   // fallback avatar if unsafe


### PR DESCRIPTION
Potential fix for [https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/40](https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/40)

To robustly prevent XSS via a user-controlled string included in an `<img src={...}>`, we should ensure that the sanitizer for avatar URLs is strict. 

- **General approach**: Harden the `sanitizeUrl` function with stricter checks using a regular expression that only allows true HTTP(S) URLs (with optional image extensions), and, if allowing data URLs, tightly restrict them to only safe image types. Strip whitespace and reject anything suspicious. Do not allow other URL schemes.
- **Specific changes**:  
  - In `src/components/product/ProductCard.tsx`, revise the `sanitizeUrl` function to use a regular expression that robustly matches only HTTP/HTTPS URLs and very specific data URLs (e.g., only `data:image/png`, `data:image/jpeg`, etc.).
  - Optionally strip whitespace from the beginning and end of the input URL as part of sanitation.
  - If the input fails the regex test, always return the fallback avatar.

No other code changes elsewhere are required, as all avatar rendering goes through this sanitizer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
