### PR TITLE
Potential fix for code scanning alert no. 39: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/common/ImageWithFallback.tsx
+++ b/src/components/common/ImageWithFallback.tsx
@@ -2,19 +2,32 @@ import React, { useState, useRef } from 'react';
 import { ImageIcon, ZoomIn } from 'lucide-react';
 import { sanitizeAltText } from '../../utils/helpers';
 
-// Only allow HTTP(S) and safe image data URLs (reject javascript:, unknown, base64 SVG, ...)
+// Only allow safe HTTP(S) avatar/image hosts and safe image data URLs
 function sanitizeImageSrc(input?: string): string {
   if (!input || typeof input !== 'string') return '';
   try {
-    // Allow only https/http/image data URLs
     input = input.trim();
-    if (
-      input.startsWith('http://') ||
-      input.startsWith('https://')
-    ) {
-      return input;
+
+    // List of explicitly trusted image hosts (expand as your app needs)
+    const trustedHosts = [
+      'i.pravatar.cc',
+      // Add other whitelisted hosts here, e.g. 'my-trusted-domain.com'
+    ];
+
+    // If it's a valid http(s) url, check host allow-list
+    if (input.startsWith('http://') || input.startsWith('https://')) {
+      try {
+        const url = new URL(input);
+        // Only allow if host in trusted list
+        if (trustedHosts.includes(url.hostname)) {
+          return input;
+        }
+      } catch {
+        return '';
+      }
     }
-    // Optionally: allow only safe image/* data URLs, block SVG/data with potential script
+
+    // Allow only image/png, image/jpeg, image/gif, image/webp data URLs (NOT SVG!)
     if (
       input.startsWith('data:image/png') ||
       input.startsWith('data:image/jpeg') ||


### PR DESCRIPTION
Potential fix for [https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/39](https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/39)

To fix the problem, stricter validation should be implemented in `sanitizeImageSrc`. Instead of permitting arbitrary `http://` or `https://` URLs, the application should enforce that avatar images originate either from a fixed allow-list of trusted domains (such as `i.pravatar.cc` or other trusted avatar/image providers), or fallback to an internally-generated image if the supplied URL does not meet the criteria. Disallow user-provided or arbitrary domain images as profile avatars.  

The `sanitizeImageSrc` function should check not just the protocol but also verify the host against a strict allow-list (e.g., only allow `i.pravatar.cc` for avatars, or other statically known sources). For all image types, reject any url if it is not from an explicitly trusted set. This method maintains existing functionality (profile images and product images are still loaded from trusted, known locations), while preventing user-supplied links that could be abused. This fix touches only `src/components/common/ImageWithFallback.tsx`, by updating the sanitizer implementation.

**Summary:**
- In `src/components/common/ImageWithFallback.tsx`:
  - Enhance `sanitizeImageSrc` to allow only URLs from a specific allow-list of hosts (e.g., `i.pravatar.cc`), *and* the previously allowed safe data URLs.
  - Optionally, create a generic `isTrustedUrl` function for reuse/testing.
  - All other usage of `sanitizeImageSrc` remains unchanged; only its implementation improves.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
