### PR TITLE
Potential fix for code scanning alert no. 43: DOM text reinterpreted as HTML

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -50,12 +50,14 @@ export const sanitizeAvatarUrl = (url?: string): string => {
   if (!url || typeof url !== 'string') return 'https://i.pravatar.cc/150?img=1';
   url = url.trim();
 
-  const httpUrlRegex = /^https?:\/\/[^\s]+(\.(jpg|jpeg|png|gif|webp|svg))?([?#][^\s]*)?$/i;
-  const dataImageRegex = /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,[A-Za-z0-9+\/=]+$/i;
+  // Allow only http(s) URLs ending in .jpg, .jpeg, .png, .gif, or .webp (no .svg, no data URIs)
+  const safeImgExts = /\.(jpg|jpeg|png|gif|webp)(\?.*)?$/i;
+  const httpUrlRegex = /^https?:\/\/[^\s]+$/i;
 
-  if (httpUrlRegex.test(url) || dataImageRegex.test(url)) {
+  if (httpUrlRegex.test(url) && safeImgExts.test(url)) {
     return url;
   }
 
+  // Fallback to default avatar if unsafe or not matched
   return 'https://i.pravatar.cc/150?img=1';
 };


### PR DESCRIPTION
Potential fix for [https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/43](https://github.com/DibyadyutiDas/group-buying-platform/security/code-scanning/43)

To fix this, we should tighten the sanitization of the `avatar` property in user objects. Specifically, the `sanitizeAvatarUrl` function in `src/utils/helpers.ts` should **disallow data URIs entirely** and prevent any URLs ending in .svg or with the MIME type svg+xml. Only allow HTTP(S) URLs ending in standard static image extensions (jpg, jpeg, png, gif, webp) or from a known safelist (e.g., pravatar), and never data URIs, especially those of SVG type. Update `sanitizeAvatarUrl` so that any potentially unsafe values (including data URIs and SVG files) default to the fallback avatar.

Edit only the relevant function in `src/utils/helpers.ts` (the function that generates and validates the avatar URL). No changes are needed to code that uses this function, because the function's semantics remain the same, it simply becomes stricter in what images it allows.

#### Required changes:
- Edit the definition of `sanitizeAvatarUrl` in `src/utils/helpers.ts` to disallow:
  - Any data URI, regardless of image type.
  - Any HTTP(S) URL ending in `.svg` or with a content type of SVG.
- Default to `'https://i.pravatar.cc/150?img=1'` if not passing the checks.
- No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
